### PR TITLE
feat: create group model

### DIFF
--- a/src/models/Group.ts
+++ b/src/models/Group.ts
@@ -1,0 +1,48 @@
+import { Model, DataTypes, Optional } from "sequelize";
+import sequelize from "../config/database";
+
+interface GroupAttributes {
+    id: number;
+    name: string;
+    description?: string | null;
+    createdAt?: Date;
+    updatedAt?: Date;
+}
+
+interface GroupCreationAttributes extends Optional<GroupAttributes, 'id' | 'createdAt' | 'updatedAt'> {}
+
+class Group extends Model<GroupAttributes, GroupCreationAttributes> implements GroupAttributes {
+    public id!: number;
+    public name!: string;
+    public description?: string | null = null;
+
+    // Timestamps
+    public readonly createdAt!: Date;
+    public readonly updatedAt!: Date;
+}
+
+Group.init(
+    {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        name: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        description: {
+            type: DataTypes.STRING,
+            allowNull: true,
+        },
+    },
+    {
+        sequelize,
+        modelName: 'Group',
+        tableName: 'groups',
+        timestamps: true,
+    }
+);
+
+export default Group;


### PR DESCRIPTION
Se crea el modelo Group con sus atributos y configuración base utilizando Sequelize. Este modelo representa a los grupos que pueden ser asignados a los usuarios dentro de la API. 

Definición de los atributos:

- id: Identificador autoincremental.
- name: Nombre del grupo (obligatorio).
- description: Descripción del grupo (opcional).

Configuración de Sequelize con:

- timestamps: true para que maneje automáticamente createdAt y updatedAt.