### PR TITLE
refactor: usar función utilitaria formatError para manejar errores

### DIFF
--- a/src/controllers/groupController.ts
+++ b/src/controllers/groupController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { GroupService } from "../services/groupService";
 import { ApiResponse } from '../types/apiTypes';
 import { CreateGroupRequest } from '../types/groupTypes';
+import { formatError } from "../utils/formatError";
 
 export const getAllGroups = async (_req: Request, res: Response<ApiResponse>) => {
     try {
@@ -15,7 +16,7 @@ export const getAllGroups = async (_req: Request, res: Response<ApiResponse>) =>
         return res.status(500).json({
             success: false,
             message: "Error al obtener los grupos",
-            error: error instanceof Error ? error.message : String(error)
+            error: formatError(error)
         });
     }
 };
@@ -39,7 +40,7 @@ export const getGroupById = async (req: Request, res: Response<ApiResponse>) => 
         return res.status(500).json({
             success: false,
             message: "Error al obtener el grupo",
-            error: error instanceof Error ? error.message : String(error)
+            error: formatError(error)
         });
     }
 };
@@ -56,7 +57,7 @@ export const createGroup = async (req: Request<{}, {}, CreateGroupRequest>, res:
         return res.status(500).json({
             success: false,
             message: "Error al crear el grupo",
-            error: error instanceof Error ? error.message : String(error)
+            error: formatError(error)
         });
     }
 };
@@ -80,7 +81,7 @@ export const updateGroup = async (req: Request, res: Response<ApiResponse>) => {
         return res.status(500).json({
             success: false,
             message: "Error al actualizar el grupo",
-            error: error instanceof Error ? error.message : String(error)
+            error: formatError(error)
         });
     }
 };
@@ -104,7 +105,7 @@ export const deleteGroup = async (req: Request, res: Response<ApiResponse>) => {
         return res.status(500).json({
             success: false,
             message: "Error al eliminar el grupo",
-            error: error instanceof Error ? error.message : String(error)
+            error: formatError(error)
         });
     }
 };


### PR DESCRIPTION
Este PR actualiza el controlador de grupos para usar la función utilitaria `formatError` en todos los bloques `catch`. Con esto, se centraliza el formato de mensajes de error, mejorando la legibilidad, mantenibilidad y coherencia del proyecto.

Cambios realizados:
- Reemplazo de `error instanceof Error ? error.message : String(error)` por `formatError(error)` en el controlador de Group.
- Se mantiene la estructura de respuesta estándar con `ApiResponse`.
