### PR TITLE
feat: crear y centralizar asociaciones Sequelize en associations.ts y…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,9 @@ import fileRouter from './routes/fileRoute';
 import moduleRouter from './routes/moduleRoute';
 import statusTicketRouter from './routes/statusTicketRoute';
 import responseTicketRouter from './routes/responseTicketRoutes';
+import { applyAssociations } from './models/associations';
+
+applyAssociations(); // Aquí se aplican las asociaciones entre modelos
 
 const app = express();
 

--- a/src/models/File.ts
+++ b/src/models/File.ts
@@ -23,7 +23,7 @@ interface FileAttributes {
     updatedAt?: Date;
 }
 
-interface FileCreationAttributes extends Optional<FileAttributes, 'id' | 'description' | 'expiration_date' | 'is_valid' | 'response_ticket_id' | 'createdAt' | 'updatedAt'> {}
+interface FileCreationAttributes extends Optional<FileAttributes, 'id' | 'description' | 'expiration_date' | 'is_valid' | 'response_ticket_id' | 'createdAt' | 'updatedAt'> { }
 
 class File extends Model<FileAttributes, FileCreationAttributes> implements FileAttributes {
     public id!: number;
@@ -41,13 +41,6 @@ class File extends Model<FileAttributes, FileCreationAttributes> implements File
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 
-    static associate( ){
-        File.belongsTo(User,{foreignKey: 'uploaded_by', as: 'uploader'});
-        File.belongsTo(CatchmentPoint, { foreignKey: 'catchment_point_id', as: 'catchmentPoint' });
-        File.belongsTo(FileType, { foreignKey: 'file_type_id', as: 'fileType' });
-        File.belongsTo(ResponseTicket, { foreignKey: 'response_ticket_id', as: 'responseTicket' });
-        File.belongsTo(Quotation, { foreignKey: 'quotation_id', as: 'quotation' });
-    }
 };
 
 File.init(
@@ -60,7 +53,7 @@ File.init(
         catchment_point_id: {
             type: DataTypes.INTEGER,
             allowNull: false,
-            references:{
+            references: {
                 model: CatchmentPoint,
                 key: 'id',
             }
@@ -105,7 +98,7 @@ File.init(
         uploaded_by: {
             type: DataTypes.INTEGER,
             allowNull: false,
-            references:{
+            references: {
                 model: User,
                 key: 'id',
             }

--- a/src/models/FileType.ts
+++ b/src/models/FileType.ts
@@ -9,7 +9,7 @@ interface FileTypeAttributes {
     updatedAt?: Date;
 };
 
-interface FileTypeCreationAttributes extends Optional<FileTypeAttributes, 'id' | 'description' | 'createdAt' | 'updatedAt'> {}
+interface FileTypeCreationAttributes extends Optional<FileTypeAttributes, 'id' | 'description' | 'createdAt' | 'updatedAt'> { }
 
 class FileType extends Model<FileTypeAttributes, FileTypeCreationAttributes> implements FileTypeAttributes {
     public id!: number;

--- a/src/models/Group.ts
+++ b/src/models/Group.ts
@@ -1,7 +1,5 @@
 import { Model, DataTypes, Optional } from "sequelize";
 import sequelize from "../config/database";
-import User from "./User";
-import Permission from "./Permission";
 
 interface GroupAttributes {
     id: number;
@@ -9,7 +7,7 @@ interface GroupAttributes {
     description?: string | null;
     createdAt?: Date;
     updatedAt?: Date;
-}
+};
 
 interface GroupCreationAttributes extends Optional<GroupAttributes, 'id' | 'createdAt' | 'updatedAt'> { }
 
@@ -22,10 +20,6 @@ class Group extends Model<GroupAttributes, GroupCreationAttributes> implements G
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 
-    static associate(models: { User: typeof User; Permission: typeof Permission }) {
-        Group.hasMany(models.User, { foreignKey: "group_id", as: "users" });
-        Group.hasMany(models.Permission, { foreignKey: "group_id", as: "permissions" });
-    }
 };
 
 Group.init(

--- a/src/models/Permission.ts
+++ b/src/models/Permission.ts
@@ -15,7 +15,7 @@ interface PermissionAttributes {
     updated_at?: Date;
 };
 
-interface PermissionCreationAttributes extends Optional<PermissionAttributes, 'id' | 'created_at' | 'updated_at'> {}
+interface PermissionCreationAttributes extends Optional<PermissionAttributes, 'id' | 'created_at' | 'updated_at'> { }
 
 class Permission extends Model<PermissionAttributes, PermissionCreationAttributes> implements PermissionAttributes {
     public id!: number;
@@ -30,16 +30,12 @@ class Permission extends Model<PermissionAttributes, PermissionCreationAttribute
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 
-    static associate() {
-        Permission.belongsTo(Group, { foreignKey: 'group_id', as: 'group' });
-        Permission.belongsTo(Module, { foreignKey: 'module_id', as: 'module' });
 };
-} 
 
 
 Permission.init(
     {
-        id:{
+        id: {
             type: DataTypes.INTEGER,
             autoIncrement: true,
             primaryKey: true
@@ -80,12 +76,12 @@ Permission.init(
                 key: 'id',
             }
         }
-},
-{
-    sequelize,
-    modelName: 'Permission',
-    tableName: 'permissions',
-    timestamps: true,
-});
+    },
+    {
+        sequelize,
+        modelName: 'Permission',
+        tableName: 'permissions',
+        timestamps: true,
+    });
 
 export default Permission;

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -13,7 +13,7 @@ interface TaskAttributes {
     updatedAt?: Date;
 }
 
-interface TaskCreationAttributes extends Optional<TaskAttributes, "id" | "description" | "createdAt" | "updatedAt"> {}
+interface TaskCreationAttributes extends Optional<TaskAttributes, "id" | "description" | "createdAt" | "updatedAt"> { }
 
 class Task extends Model<TaskAttributes, TaskCreationAttributes> implements TaskAttributes {
     public id!: number;
@@ -26,11 +26,7 @@ class Task extends Model<TaskAttributes, TaskCreationAttributes> implements Task
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 
-    // Define associations
-    static associate() {
-        Task.belongsTo(User, { foreignKey: "created_by", as: "creator" });
-    }
-}
+};
 
 Task.init(
     {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -13,7 +13,7 @@ interface UserAttributes {
     is_verified: boolean;
     verify_token?: string | null;
     verify_token_expiration?: Date | null;
-    rol: 'admin' | 'client' | 'inner_user' | 'viewer_user';
+    rol: UserRole;
     is_active: boolean;
     last_login?: Date | null;
     last_password_change?: Date | null;
@@ -48,9 +48,6 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 
-    static associate() {
-        User.belongsTo(Group, { foreignKey: "group_id", as: "group" });
-    };
 };
 
 User.init(

--- a/src/models/associations.ts
+++ b/src/models/associations.ts
@@ -1,0 +1,73 @@
+import User from "./User";
+import Group from "./Group";
+import Task from "./Task";
+import Permission from "./Permission";
+import FileType from "./FileType";
+import File from "./File";
+import CatchmentPoint from "./CatchmentPoint";
+import ResponseTicket from "./ResponseTicket";
+import Quotation from "./Quotation";
+
+export const applyAssociations = () => {
+    // User --- Group
+    Group.hasMany(User, {
+        foreignKey: "group_id", as: "users"
+    });
+    User.belongsTo(Group, {
+        foreignKey: "group_id", as: "group"
+    });
+
+    // User --- Task
+    User.hasMany(Task, {
+        foreignKey: "created_by", as: "createdTasks"
+    });
+    Task.belongsTo(User, {
+        foreignKey: "created_by", as: "creator"
+    });
+
+    // Group --- Permission
+    Group.hasMany(Permission, {
+        foreignKey: "group_id", as: "permissions"
+    });
+    Permission.belongsTo(Group, {
+        foreignKey: "group_id", as: "group"
+    });
+
+    // FileType --- File
+    FileType.hasMany(File, {
+        foreignKey: "file_type_id", as: "files"
+    });
+    File.belongsTo(FileType, {
+        foreignKey: "file_type_id", as: "fileType"
+    });
+    
+    // CatchmentPoint --- File
+    CatchmentPoint.hasMany(File, {
+        foreignKey: 'catchment_point_id',
+        as: 'files',
+    });
+    File.belongsTo(CatchmentPoint, {
+        foreignKey: 'catchment_point_id',
+        as: 'catchmentPoint',
+    });
+
+    // ResponseTicket --- File
+    ResponseTicket.hasMany(File, {
+        foreignKey: 'response_ticket_id',
+        as: 'files',
+    });
+    File.belongsTo(ResponseTicket, {
+        foreignKey: 'response_ticket_id',
+        as: 'responseTicket',
+    });
+
+    // Quotation --- File
+    Quotation.hasMany(File, {
+        foreignKey: 'quotation_id',
+        as: 'files',
+    });
+    File.belongsTo(Quotation, {
+        foreignKey: 'quotation_id',
+        as: 'quotation',
+    });
+}


### PR DESCRIPTION
Este PR realiza una refactorización estructural al centralizar todas las asociaciones (hasMany, belongsTo) entre modelos Sequelize en un único archivo: 

> src/models/associations.ts.

**Cambios principales:**

- Creación del archivo src/models/associations.ts.
- Migración de asociaciones desde los modelos individuales (User, File, Task, Group, FileType y Permission) hacia associations.ts.
- Eliminación de métodos associate() y llamadas a .belongsTo() / .hasMany() dentro de los modelos individuales.
